### PR TITLE
Typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ in many of your log statements.
 LogglyLogger will use the bundle id of your app as a Loggly tag. You can create a "source group" in Loggly
 that contains all log statements that has a specific tag. This way, you can easily use the same Loggly
 account for many apps. If you don't want to use the bundle id as the tag or if you want to
-use multiple tags, you can set the property logglyTags in the LogglyFormatter.
+use multiple tags, you can set the property logglyTags in the LogglyLogger.
 (comma-separated list of tags, no whitespace in or between tags)
 
 ###LogglyLogger settings


### PR DESCRIPTION
logglyTags property is in file LogglyLogger not LogglyFormatter
