### PR TITLE
Fix #5 LogglyLogger object should remove itself as an observer from NSNo...

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyLogger.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyLogger.m
@@ -40,6 +40,10 @@
     return self;
 }
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 #pragma mark Overridden methods from DDAbstractDatabaseLogger
 


### PR DESCRIPTION
Fix #5 LogglyLogger object should remove itself as an observer from NSNotificationCenter notifications.
