### PR TITLE
Support for iOS8 extensions compatibility

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyLogger.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyLogger.m
@@ -132,10 +132,12 @@
     }
     AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
     // Make sure the post request can finish in background
+#ifndef AF_APP_EXTENSIONS
     [operation setShouldExecuteAsBackgroundTaskWithExpirationHandler:^{
         // Handle what to do when the background time has been consumed and iOS will shut us down
         // So, let's do... nothing at all
     }];
+#endif
 
     [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         NSString *response = [[NSString alloc]initWithData:responseObject encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Removed reference to `setShouldExecuteAsBackgroundTaskWithExpirationHandler` for extensions compatibility in iOS8 (no such thing as background tasks in extensions so the compiler will balk if this code is included in extensions).

This uses the AF_APP_EXTENSIONS variable already defined by AFNetworking (For reference, see the AFNetworking release notes for version 2.3.0 https://github.com/AFNetworking/AFNetworking/releases) so it will just work without the need to create an ad-hoc variable.
