### PR TITLE
Copy messages array to prevent concurrent modification exception

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyLogger.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyLogger.m
@@ -96,7 +96,7 @@
     }
 
     // Get reference to log messages
-    NSArray *oldLogMessagesArray = _logMessagesArray;
+    NSArray *oldLogMessagesArray = [_logMessagesArray copy];
 
     // reset array
     _logMessagesArray = [NSMutableArray arrayWithCapacity:0];


### PR DESCRIPTION
Fixes #12 by copying the log messages array.
