### PR TITLE
Fix for cocoalumberjack 2.0b

### DIFF
--- a/Examples/ExampleProject/Podfile
+++ b/Examples/ExampleProject/Podfile
@@ -1,4 +1,4 @@
 platform :ios, '6.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
-pod 'LogglyLogger-CocoaLumberjack', :path => '../../../LogglyLogger-CocoaLumberjack'
+pod 'LogglyLogger-CocoaLumberjack', :path => '../../'

--- a/Examples/ExampleProject/Podfile.lock
+++ b/Examples/ExampleProject/Podfile.lock
@@ -6,38 +6,42 @@ PODS:
     - AFNetworking/Security (= 2.5.1)
     - AFNetworking/Serialization (= 2.5.1)
     - AFNetworking/UIKit (= 2.5.1)
+  - AFNetworking/NSURLConnection (2.5.1):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.5.1):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.5.1)
+  - AFNetworking/Security (2.5.1)
+  - AFNetworking/Serialization (2.5.1)
+  - AFNetworking/UIKit (2.5.1):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
   - CocoaLumberjack (2.0.0):
     - CocoaLumberjack/Default (= 2.0.0)
     - CocoaLumberjack/Extensions (= 2.0.0)
   - CocoaLumberjack/Core (2.0.0)
   - CocoaLumberjack/Default (2.0.0):
+    - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.0.0):
-    - CocoaLumberjack/Default
-  - LogglyLogger-CocoaLumberjack (0.3.2):
-  - LogglyLogger-CocoaLumberjack (0.3.0):
-  - CocoaLumberjack/Extensions (2.0.0-rc):
     - CocoaLumberjack/Default
   - LogglyLogger-CocoaLumberjack (0.3.2):
     - AFNetworking (~> 2.0)
     - CocoaLumberjack (~> 2.0.0)
+
+DEPENDENCIES:
+  - LogglyLogger-CocoaLumberjack (from `../../`)
 
 EXTERNAL SOURCES:
   LogglyLogger-CocoaLumberjack:
     :path: ../../
 
 SPEC CHECKSUMS:
-<<<<<<< HEAD
   AFNetworking: 8bee59492a6ff15d69130efa4d0dc67e0094a52a
   CocoaLumberjack: fd2b1031c6c4e0f08b5ea928ef677fa0a5de517d
   LogglyLogger-CocoaLumberjack: 77e3a4aba92b39858f3df258d2f5c6fc9613cf59
-||||||| merged common ancestors
-  AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
-  LogglyLogger-CocoaLumberjack: 4b0cfe78c112ae03e70a3d3ba7021ff179797916
-=======
-  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
-  CocoaLumberjack: 6186e27827fc574b50b16c10102fcc591437f06c
-  LogglyLogger-CocoaLumberjack: a42b48d9ef529de8ab1eae5f85618550b8e0d010
->>>>>>> 85d8163366a3a2361cc031ea865744502ba21c88
 
 COCOAPODS: 0.35.0

--- a/Examples/ExampleProject/Podfile.lock
+++ b/Examples/ExampleProject/Podfile.lock
@@ -1,44 +1,47 @@
 PODS:
-  - AFNetworking (2.4.1):
+  - AFNetworking (2.5.1):
+    - AFNetworking/NSURLConnection (= 2.5.1)
+    - AFNetworking/NSURLSession (= 2.5.1)
+    - AFNetworking/Reachability (= 2.5.1)
+    - AFNetworking/Security (= 2.5.1)
+    - AFNetworking/Serialization (= 2.5.1)
+    - AFNetworking/UIKit (= 2.5.1)
+  - AFNetworking/NSURLConnection (2.5.1):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.5.1):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.5.1)
+  - AFNetworking/Security (2.5.1)
+  - AFNetworking/Serialization (2.5.1)
+  - AFNetworking/UIKit (2.5.1):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-    - AFNetworking/UIKit
-  - AFNetworking/NSURLConnection (2.4.1):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.4.1):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.4.1)
-  - AFNetworking/Security (2.4.1)
-  - AFNetworking/Serialization (2.4.1)
-  - AFNetworking/UIKit (2.4.1):
-    - AFNetworking/NSURLConnection
-    - AFNetworking/NSURLSession
-  - CocoaLumberjack (1.9.2):
-    - CocoaLumberjack/Extensions
-  - CocoaLumberjack/Core (1.9.2)
-  - CocoaLumberjack/Extensions (1.9.2):
+  - CocoaLumberjack (2.0.0):
+    - CocoaLumberjack/Default (= 2.0.0)
+    - CocoaLumberjack/Extensions (= 2.0.0)
+  - CocoaLumberjack/Core (2.0.0)
+  - CocoaLumberjack/Default (2.0.0):
     - CocoaLumberjack/Core
-  - LogglyLogger-CocoaLumberjack (0.3.0):
+  - CocoaLumberjack/Extensions (2.0.0):
+    - CocoaLumberjack/Default
+  - LogglyLogger-CocoaLumberjack (0.3.2):
     - AFNetworking (~> 2.0)
-    - CocoaLumberjack (~> 1.6)
+    - CocoaLumberjack (~> 2.0.0)
 
 DEPENDENCIES:
-  - LogglyLogger-CocoaLumberjack (from `../../../LogglyLogger-CocoaLumberjack`)
+  - LogglyLogger-CocoaLumberjack (from `../../`)
 
 EXTERNAL SOURCES:
   LogglyLogger-CocoaLumberjack:
-    :path: ../../../LogglyLogger-CocoaLumberjack
+    :path: ../../
 
 SPEC CHECKSUMS:
-  AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
-  LogglyLogger-CocoaLumberjack: 4b0cfe78c112ae03e70a3d3ba7021ff179797916
+  AFNetworking: 8bee59492a6ff15d69130efa4d0dc67e0094a52a
+  CocoaLumberjack: fd2b1031c6c4e0f08b5ea928ef677fa0a5de517d
+  LogglyLogger-CocoaLumberjack: 77e3a4aba92b39858f3df258d2f5c6fc9613cf59
 
-COCOAPODS: 0.34.4
+COCOAPODS: 0.35.0

--- a/LogglyLogger-CocoaLumberjack.podspec
+++ b/LogglyLogger-CocoaLumberjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "LogglyLogger-CocoaLumberjack"
-  s.version      = "0.3.1"
+  s.version      = "0.3.2"
   s.summary      = "LogglyLogger-CocoaLumberjack is a custom logger for CocoaLumberjack that logs to Loggly"
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '6.0'
 
-  s.source       = { :git => "https://github.com/melke/LogglyLogger-CocoaLumberjack.git", :tag => "0.3.1" }
+  s.source       = { :git => "https://github.com/melke/LogglyLogger-CocoaLumberjack.git", :tag => "0.3.2" }
 
   s.source_files  = 'LogglyLogger-CocoaLumberjack', 'LogglyLogger-CocoaLumberjack/**/*.{h,m}'
   s.requires_arc = true

--- a/LogglyLogger-CocoaLumberjack.podspec
+++ b/LogglyLogger-CocoaLumberjack.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |s|
                    LogglyLogger-CocoaLumberjack let's you log to the cloud service.
                    The logger extends the excellent base class DDAbstractDatabaseLogger, that makes
                    sure that the threading model is correct and that the logs are not constantly being
-                   saved. 
+                   saved.
                    Besides posting JSON to Loggly, LogglyLogger-CocoaLumberjack will add:
                    - Sending standard info about the device, like os-version, lang setting etc
                    - Automatic session number generation, which will help you search for log entires by session in the Loggly web interface
                    - (Optional) Custom user specific id for each session
-                   - (Optional) Changing loglevel for a session  
+                   - (Optional) Changing loglevel for a session
                    DESC
 
   s.homepage     = "https://github.com/melke/LogglyLogger-CocoaLumberjack"
@@ -27,6 +27,6 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'LogglyLogger-CocoaLumberjack', 'LogglyLogger-CocoaLumberjack/**/*.{h,m}'
   s.requires_arc = true
-  s.dependency     'CocoaLumberjack'
+  s.dependency     'CocoaLumberjack', '~> 2.0.0'
   s.dependency     'AFNetworking', '~> 2.0'
 end

--- a/LogglyLogger-CocoaLumberjack.podspec
+++ b/LogglyLogger-CocoaLumberjack.podspec
@@ -27,6 +27,6 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'LogglyLogger-CocoaLumberjack', 'LogglyLogger-CocoaLumberjack/**/*.{h,m}'
   s.requires_arc = true
-  s.dependency     'CocoaLumberjack', '~> 1.6'
+  s.dependency     'CocoaLumberjack'
   s.dependency     'AFNetworking', '~> 2.0'
 end

--- a/LogglyLogger-CocoaLumberjack/LogglyLogger.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyLogger.m
@@ -50,7 +50,7 @@
 {
     // Return YES if an item was added to the buffer.
     // Return NO if the logMessage was ignored.
-    if (!self->formatter) {
+    if (!self->_logFormatter) {
         // No formatter set, don't log
 #ifdef DEBUG
         NSLog(@"No formatter set in LogglyLogger. Will not log anything.");
@@ -70,7 +70,7 @@
         return YES;
     }
 
-    [_logMessagesArray addObject:[self->formatter formatLogMessage:logMessage]];
+    [_logMessagesArray addObject:[self->_logFormatter formatLogMessage:logMessage]];
     return YES;
 }
 
@@ -179,7 +179,7 @@
     NSLog(@"Suspending, posting logs to Loggly");
 #endif
     
-    dispatch_async(loggerQueue, ^{
+    dispatch_async(_loggerQueue, ^{
         [self db_save];
     });
 }


### PR DESCRIPTION
Opening this up for discussion: 

This updates for CocoaLumberjack 2.0.0-beta4 release. Since its a pre-release I'll update this accordingly when i notice a new release has happened. 

Most of the changes are just with accessing variables and dealing with renames.

This should (probably) not be merged until v2.0.0 of CocoaLumberjack is officially released also.