### PR TITLE
separate formatter into subspec so you can depend on it without afnetworking

### DIFF
--- a/LogglyLogger-CocoaLumberjack.podspec
+++ b/LogglyLogger-CocoaLumberjack.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |s|
                    LogglyLogger-CocoaLumberjack let's you log to the cloud service.
                    The logger extends the excellent base class DDAbstractDatabaseLogger, that makes
                    sure that the threading model is correct and that the logs are not constantly being
-                   saved. 
+                   saved.
                    Besides posting JSON to Loggly, LogglyLogger-CocoaLumberjack will add:
                    - Sending standard info about the device, like os-version, lang setting etc
                    - Automatic session number generation, which will help you search for log entires by session in the Loggly web interface
                    - (Optional) Custom user specific id for each session
-                   - (Optional) Changing loglevel for a session  
+                   - (Optional) Changing loglevel for a session
                    DESC
 
   s.homepage     = "https://github.com/melke/LogglyLogger-CocoaLumberjack"
@@ -25,8 +25,15 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/melke/LogglyLogger-CocoaLumberjack.git", :tag => "0.3.2" }
 
-  s.source_files  = 'LogglyLogger-CocoaLumberjack', 'LogglyLogger-CocoaLumberjack/**/*.{h,m}'
   s.requires_arc = true
   s.dependency     'CocoaLumberjack', '~> 1.6'
-  s.dependency     'AFNetworking', '~> 2.0'
+
+  s.subspec 'Formatter' do |ss|
+    ss.source_files = 'LogglyLogger-CocoaLumberjack/{LogglyFields,LogglyFormatter}.{h,m}'
+  end
+
+  s.subspec 'Logger' do |ss|
+    ss.source_files = 'LogglyLogger-CocoaLumberjack/LogglyLogger.{h,m}'
+    ss.dependency     'AFNetworking', '~> 2.0'
+  end
 end


### PR DESCRIPTION
Thanks for the pod.  I'd like to use the formatter portion with https://github.com/pushd/BackgroundUpload-CocoaLumberjack but don't want to add a dependency on AFNetworking 2.0.  This pull request just makes it so you can depend on LogglyLogger-CocoaLumberjack/Formatter to do that, but through the magic of subspecs there is no other change for those requiring the full thing.