### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In your App Delegate:
 
     #import "LogglyLogger.h"
     #import "LogglyFormatter.h"
-    static const int ddLogLevel = LOG_LEVEL_VERBOSE;
+    static const int ddLogLevel = DDLogLevelVerbose;
 
 In didFinishLaunchingWithOptions
 


### PR DESCRIPTION
Changed `LOG_LEVEL_VERBOSE` to `DDLogLevelVerbose` as the `ddLogLevel` definition.  Required to get AppDelegate.m to compile.