### PR TITLE
Make LogglyFields appversion settable

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyFields.h
+++ b/LogglyLogger-CocoaLumberjack/LogglyFields.h
@@ -6,6 +6,7 @@
 #import "LogglyFormatter.h"
 
 @interface LogglyFields : NSObject <LogglyFieldsDelegate>
+@property (strong, nonatomic) NSString *appversion;
 @property (strong, nonatomic) NSString *userid;
 @property (strong, nonatomic) NSString *sessionid;
 @end

--- a/LogglyLogger-CocoaLumberjack/LogglyFields.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyFields.m
@@ -45,6 +45,14 @@
 
 #pragma mark Property setters
 
+- (void)setAppversion:(NSString *)appversion {
+    dispatch_barrier_async(_queue, ^{
+        NSMutableDictionary *dict = [_fieldsDictionary mutableCopy];
+        [dict setObject:appversion forKey:@"appversion"];
+        _fieldsDictionary = [NSDictionary dictionaryWithDictionary:dict];
+    });
+}
+
 - (void)setSessionid:(NSString *)sessionid {
     dispatch_barrier_async(_queue, ^{
         NSMutableDictionary *dict = [_fieldsDictionary mutableCopy];

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This is all there is to it. The log posts will include all the json fields that 
   - **file** - The name of the source file that logged the message
   - **fileandlinenumber** - Source file and line number in that file (nice for doing facet searches in Loggly)
   - **appname** - The Display name of your app
-  - **appversion** - The version of your app
+  - **appversion** - The version of your app. You can override by setting your own appversion in the LogglyFields object.
   - **devicemodel** - The device model
   - **devicename** - The device name
   - **lang** - The primary lang the app user has selected in Settings on the device


### PR DESCRIPTION
Useful if using something other than CFBundleVersion to set appversion.