### PR TITLE
Import the UIKit module

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyFields.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyFields.m
@@ -4,7 +4,7 @@
 
 #import "LogglyFields.h"
 
-
+@import UIKit;
 
 @implementation LogglyFields {
     dispatch_queue_t _queue;


### PR DESCRIPTION
UIDevice is used in this file, and previously Xcode would give an error when building as UIKit was not imported.