### PR TITLE
in XCode 7.3 and 8.0 you need to define the ddLogLevel as DDLogLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In your App Delegate:
 
     #import "LogglyLogger.h"
     #import "LogglyFormatter.h"
-    static const int ddLogLevel = DDLogLevelVerbose;
+    static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
 
 In didFinishLaunchingWithOptions
 


### PR DESCRIPTION
Don't know what has changed, but in XCode 7.3 and 8.0 you need to define the ddLogLevel as `DDLogLevel`, complier will not accept `int` .