### PR TITLE
Add OSX support to Podspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 .idea/
 *.hmap
 *.xccheckout
+build/
 
 #CocoaPods
 Pods

--- a/Examples/ExampleProject/ExampleMacProject.xcodeproj/project.pbxproj
+++ b/Examples/ExampleProject/ExampleMacProject.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		EBFC6B85F283994E83818BB2 /* [CP] Copy Pods Resources */ = {

--- a/Examples/ExampleProject/ExampleMacProject.xcodeproj/project.pbxproj
+++ b/Examples/ExampleProject/ExampleMacProject.xcodeproj/project.pbxproj
@@ -1,0 +1,487 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		082A03781D761A4500DBCEAA /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 082A03771D761A4500DBCEAA /* AppDelegate.m */; };
+		082A037B1D761A4500DBCEAA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 082A037A1D761A4500DBCEAA /* main.m */; };
+		082A037E1D761A4500DBCEAA /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 082A037D1D761A4500DBCEAA /* ViewController.m */; };
+		082A03801D761A4500DBCEAA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 082A037F1D761A4500DBCEAA /* Assets.xcassets */; };
+		082A03831D761A4500DBCEAA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 082A03811D761A4500DBCEAA /* Main.storyboard */; };
+		082A038E1D761A4500DBCEAA /* ExampleMacProjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 082A038D1D761A4500DBCEAA /* ExampleMacProjectTests.m */; };
+		979C7799DAB7C587AB72ED7D /* Pods_ExampleProject_ExampleMacProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 184AEB2F62480BB51B2CD2B8 /* Pods_ExampleProject_ExampleMacProject.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		082A038A1D761A4500DBCEAA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 082A036B1D761A4500DBCEAA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 082A03721D761A4500DBCEAA;
+			remoteInfo = ExampleMacProject;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		082A03731D761A4500DBCEAA /* ExampleMacProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleMacProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		082A03761D761A4500DBCEAA /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		082A03771D761A4500DBCEAA /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		082A037A1D761A4500DBCEAA /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		082A037C1D761A4500DBCEAA /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		082A037D1D761A4500DBCEAA /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		082A037F1D761A4500DBCEAA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		082A03821D761A4500DBCEAA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		082A03841D761A4500DBCEAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		082A03891D761A4500DBCEAA /* ExampleMacProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleMacProjectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		082A038D1D761A4500DBCEAA /* ExampleMacProjectTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleMacProjectTests.m; sourceTree = "<group>"; };
+		082A038F1D761A4500DBCEAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		184AEB2F62480BB51B2CD2B8 /* Pods_ExampleProject_ExampleMacProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleProject_ExampleMacProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F74E316C4B496D8B19C32CE /* Pods-ExampleProject-ExampleMacProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject-ExampleMacProject.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject-ExampleMacProject/Pods-ExampleProject-ExampleMacProject.debug.xcconfig"; sourceTree = "<group>"; };
+		2D9D8FD9B9B9CF71BE35DB29 /* Pods-ExampleProject-ExampleMacProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject-ExampleMacProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject-ExampleMacProject/Pods-ExampleProject-ExampleMacProject.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		082A03701D761A4500DBCEAA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				979C7799DAB7C587AB72ED7D /* Pods_ExampleProject_ExampleMacProject.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		082A03861D761A4500DBCEAA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		082A036A1D761A4500DBCEAA = {
+			isa = PBXGroup;
+			children = (
+				082A03751D761A4500DBCEAA /* ExampleMacProject */,
+				082A038C1D761A4500DBCEAA /* ExampleMacProjectTests */,
+				082A03741D761A4500DBCEAA /* Products */,
+				1BA9CE7CAF09F64BBE59200C /* Pods */,
+				DF4FFE00A84B8131627DBF96 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		082A03741D761A4500DBCEAA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				082A03731D761A4500DBCEAA /* ExampleMacProject.app */,
+				082A03891D761A4500DBCEAA /* ExampleMacProjectTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		082A03751D761A4500DBCEAA /* ExampleMacProject */ = {
+			isa = PBXGroup;
+			children = (
+				082A03761D761A4500DBCEAA /* AppDelegate.h */,
+				082A03771D761A4500DBCEAA /* AppDelegate.m */,
+				082A037C1D761A4500DBCEAA /* ViewController.h */,
+				082A037D1D761A4500DBCEAA /* ViewController.m */,
+				082A037F1D761A4500DBCEAA /* Assets.xcassets */,
+				082A03811D761A4500DBCEAA /* Main.storyboard */,
+				082A03841D761A4500DBCEAA /* Info.plist */,
+				082A03791D761A4500DBCEAA /* Supporting Files */,
+			);
+			path = ExampleMacProject;
+			sourceTree = "<group>";
+		};
+		082A03791D761A4500DBCEAA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				082A037A1D761A4500DBCEAA /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		082A038C1D761A4500DBCEAA /* ExampleMacProjectTests */ = {
+			isa = PBXGroup;
+			children = (
+				082A038D1D761A4500DBCEAA /* ExampleMacProjectTests.m */,
+				082A038F1D761A4500DBCEAA /* Info.plist */,
+			);
+			path = ExampleMacProjectTests;
+			sourceTree = "<group>";
+		};
+		1BA9CE7CAF09F64BBE59200C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1F74E316C4B496D8B19C32CE /* Pods-ExampleProject-ExampleMacProject.debug.xcconfig */,
+				2D9D8FD9B9B9CF71BE35DB29 /* Pods-ExampleProject-ExampleMacProject.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		DF4FFE00A84B8131627DBF96 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				184AEB2F62480BB51B2CD2B8 /* Pods_ExampleProject_ExampleMacProject.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		082A03721D761A4500DBCEAA /* ExampleMacProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 082A03921D761A4500DBCEAA /* Build configuration list for PBXNativeTarget "ExampleMacProject" */;
+			buildPhases = (
+				3D86B44A88C9DC61C90AE23A /* [CP] Check Pods Manifest.lock */,
+				082A036F1D761A4500DBCEAA /* Sources */,
+				082A03701D761A4500DBCEAA /* Frameworks */,
+				082A03711D761A4500DBCEAA /* Resources */,
+				F62869CE0C0641AB48D2BBC0 /* [CP] Embed Pods Frameworks */,
+				EBFC6B85F283994E83818BB2 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampleMacProject;
+			productName = ExampleMacProject;
+			productReference = 082A03731D761A4500DBCEAA /* ExampleMacProject.app */;
+			productType = "com.apple.product-type.application";
+		};
+		082A03881D761A4500DBCEAA /* ExampleMacProjectTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 082A03951D761A4500DBCEAA /* Build configuration list for PBXNativeTarget "ExampleMacProjectTests" */;
+			buildPhases = (
+				082A03851D761A4500DBCEAA /* Sources */,
+				082A03861D761A4500DBCEAA /* Frameworks */,
+				082A03871D761A4500DBCEAA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				082A038B1D761A4500DBCEAA /* PBXTargetDependency */,
+			);
+			name = ExampleMacProjectTests;
+			productName = ExampleMacProjectTests;
+			productReference = 082A03891D761A4500DBCEAA /* ExampleMacProjectTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		082A036B1D761A4500DBCEAA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = Loggly;
+				TargetAttributes = {
+					082A03721D761A4500DBCEAA = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					082A03881D761A4500DBCEAA = {
+						CreatedOnToolsVersion = 7.3.1;
+						TestTargetID = 082A03721D761A4500DBCEAA;
+					};
+				};
+			};
+			buildConfigurationList = 082A036E1D761A4500DBCEAA /* Build configuration list for PBXProject "ExampleMacProject" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 082A036A1D761A4500DBCEAA;
+			productRefGroup = 082A03741D761A4500DBCEAA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				082A03721D761A4500DBCEAA /* ExampleMacProject */,
+				082A03881D761A4500DBCEAA /* ExampleMacProjectTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		082A03711D761A4500DBCEAA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				082A03801D761A4500DBCEAA /* Assets.xcassets in Resources */,
+				082A03831D761A4500DBCEAA /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		082A03871D761A4500DBCEAA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3D86B44A88C9DC61C90AE23A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		EBFC6B85F283994E83818BB2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject-ExampleMacProject/Pods-ExampleProject-ExampleMacProject-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F62869CE0C0641AB48D2BBC0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject-ExampleMacProject/Pods-ExampleProject-ExampleMacProject-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		082A036F1D761A4500DBCEAA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				082A037E1D761A4500DBCEAA /* ViewController.m in Sources */,
+				082A037B1D761A4500DBCEAA /* main.m in Sources */,
+				082A03781D761A4500DBCEAA /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		082A03851D761A4500DBCEAA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				082A038E1D761A4500DBCEAA /* ExampleMacProjectTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		082A038B1D761A4500DBCEAA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 082A03721D761A4500DBCEAA /* ExampleMacProject */;
+			targetProxy = 082A038A1D761A4500DBCEAA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		082A03811D761A4500DBCEAA /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				082A03821D761A4500DBCEAA /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		082A03901D761A4500DBCEAA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		082A03911D761A4500DBCEAA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		082A03931D761A4500DBCEAA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1F74E316C4B496D8B19C32CE /* Pods-ExampleProject-ExampleMacProject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ExampleMacProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = loggly.ExampleMacProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		082A03941D761A4500DBCEAA /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2D9D8FD9B9B9CF71BE35DB29 /* Pods-ExampleProject-ExampleMacProject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ExampleMacProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = loggly.ExampleMacProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		082A03961D761A4500DBCEAA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ExampleMacProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = loggly.ExampleMacProjectTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ExampleMacProject.app/Contents/MacOS/ExampleMacProject";
+			};
+			name = Debug;
+		};
+		082A03971D761A4500DBCEAA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ExampleMacProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = loggly.ExampleMacProjectTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ExampleMacProject.app/Contents/MacOS/ExampleMacProject";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		082A036E1D761A4500DBCEAA /* Build configuration list for PBXProject "ExampleMacProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				082A03901D761A4500DBCEAA /* Debug */,
+				082A03911D761A4500DBCEAA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		082A03921D761A4500DBCEAA /* Build configuration list for PBXNativeTarget "ExampleMacProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				082A03931D761A4500DBCEAA /* Debug */,
+				082A03941D761A4500DBCEAA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		082A03951D761A4500DBCEAA /* Build configuration list for PBXNativeTarget "ExampleMacProjectTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				082A03961D761A4500DBCEAA /* Debug */,
+				082A03971D761A4500DBCEAA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 082A036B1D761A4500DBCEAA /* Project object */;
+}

--- a/Examples/ExampleProject/ExampleMacProject/AppDelegate.h
+++ b/Examples/ExampleProject/ExampleMacProject/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  ExampleMacProject
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+
+@end
+

--- a/Examples/ExampleProject/ExampleMacProject/AppDelegate.m
+++ b/Examples/ExampleProject/ExampleMacProject/AppDelegate.m
@@ -1,0 +1,38 @@
+//
+//  AppDelegate.m
+//  ExampleMacProject
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import "AppDelegate.h"
+@import CocoaLumberjack;
+@import LogglyLogger_CocoaLumberjack;
+
+static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    LogglyLogger *logglyLogger = [[LogglyLogger alloc] init];
+    [logglyLogger setLogFormatter:[[LogglyFormatter alloc] init]];
+    logglyLogger.logglyKey = @"your-loggly-api-key";
+    
+    logglyLogger.saveInterval = 15;
+    
+    [DDLog addLogger:logglyLogger];
+    
+    // Do some logging
+    DDLogVerbose(@"{\"myJsonKey\":\"some verbose json value\"}");
+}
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification {
+    // Insert code here to tear down your application
+}
+
+@end

--- a/Examples/ExampleProject/ExampleMacProject/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/ExampleProject/ExampleMacProject/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/ExampleProject/ExampleMacProject/Base.lproj/Main.storyboard
+++ b/Examples/ExampleProject/ExampleMacProject/Base.lproj/Main.storyboard
@@ -1,0 +1,681 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="6198" systemVersion="14A297b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6198"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="ExampleMacProject" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="ExampleMacProject" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About ExampleMacProject" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide ExampleMacProject" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit ExampleMacProject" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" id="KaW-ft-85H">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="ExampleMacProject Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider=""/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller - Window-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/ExampleProject/ExampleMacProject/Info.plist
+++ b/Examples/ExampleProject/ExampleMacProject/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Loggly. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Examples/ExampleProject/ExampleMacProject/ViewController.h
+++ b/Examples/ExampleProject/ExampleMacProject/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  ExampleMacProject
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface ViewController : NSViewController
+
+
+@end
+

--- a/Examples/ExampleProject/ExampleMacProject/ViewController.m
+++ b/Examples/ExampleProject/ExampleMacProject/ViewController.m
@@ -1,0 +1,25 @@
+//
+//  ViewController.m
+//  ExampleMacProject
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Do any additional setup after loading the view.
+}
+
+- (void)setRepresentedObject:(id)representedObject {
+    [super setRepresentedObject:representedObject];
+
+    // Update the view, if already loaded.
+}
+
+@end

--- a/Examples/ExampleProject/ExampleMacProject/main.m
+++ b/Examples/ExampleProject/ExampleMacProject/main.m
@@ -1,0 +1,13 @@
+//
+//  main.m
+//  ExampleMacProject
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[]) {
+    return NSApplicationMain(argc, argv);
+}

--- a/Examples/ExampleProject/ExampleMacProjectTests/ExampleMacProjectTests.m
+++ b/Examples/ExampleProject/ExampleMacProjectTests/ExampleMacProjectTests.m
@@ -1,0 +1,39 @@
+//
+//  ExampleMacProjectTests.m
+//  ExampleMacProjectTests
+//
+//  Created by Brian Gerstle on 8/30/16.
+//  Copyright © 2016 Loggly. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface ExampleMacProjectTests : XCTestCase
+
+@end
+
+@implementation ExampleMacProjectTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/Examples/ExampleProject/ExampleMacProjectTests/Info.plist
+++ b/Examples/ExampleProject/ExampleMacProjectTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
+++ b/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1B4C316DF74241A59C7522F7 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97CA2ECF94904BA081442E00 /* libPods.a */; };
+		31DD6CE306B535C55B5DF383 /* libPods-ExampleProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */; };
 		E5D5794E18C0C5BF00CB26C6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5794D18C0C5BF00CB26C6 /* Foundation.framework */; };
 		E5D5795018C0C5BF00CB26C6 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5794F18C0C5BF00CB26C6 /* CoreGraphics.framework */; };
 		E5D5795218C0C5BF00CB26C6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5795118C0C5BF00CB26C6 /* UIKit.framework */; };
@@ -35,9 +35,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		62F8E15868BDAE2ADD4C33F5 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		7D4A04D5FB42A7EFEC05FB54 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		97CA2ECF94904BA081442E00 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject.release.xcconfig"; sourceTree = "<group>"; };
 		E5D5794A18C0C5BF00CB26C6 /* ExampleProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5D5794D18C0C5BF00CB26C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E5D5794F18C0C5BF00CB26C6 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -58,7 +58,7 @@
 		E5D5797618C0C5BF00CB26C6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E5D5797818C0C5BF00CB26C6 /* ExampleProjectTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleProjectTests.m; sourceTree = "<group>"; };
 		E5F7329018D064B9000A2930 /* LogglyLogger-CocoaLumberjack */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "LogglyLogger-CocoaLumberjack"; path = "../../LogglyLogger-CocoaLumberjack"; sourceTree = "<group>"; };
-		EE01E62399C26D7FB91B549A /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		FA2FCC238AF00E32E3435D3F /* Pods-ExampleProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,7 +69,7 @@
 				E5D5795018C0C5BF00CB26C6 /* CoreGraphics.framework in Frameworks */,
 				E5D5795218C0C5BF00CB26C6 /* UIKit.framework in Frameworks */,
 				E5D5794E18C0C5BF00CB26C6 /* Foundation.framework in Frameworks */,
-				1B4C316DF74241A59C7522F7 /* libPods.a in Frameworks */,
+				31DD6CE306B535C55B5DF383 /* libPods-ExampleProject.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,11 +86,11 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		162837F0441435379972707A /* Pods */ = {
+		765F06D768402C52A064CE0C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				EE01E62399C26D7FB91B549A /* Pods.debug.xcconfig */,
-				7D4A04D5FB42A7EFEC05FB54 /* Pods.release.xcconfig */,
+				FA2FCC238AF00E32E3435D3F /* Pods-ExampleProject.debug.xcconfig */,
+				E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -104,7 +104,7 @@
 				E5D5794C18C0C5BF00CB26C6 /* Frameworks */,
 				E5D5794B18C0C5BF00CB26C6 /* Products */,
 				62F8E15868BDAE2ADD4C33F5 /* Podfile */,
-				162837F0441435379972707A /* Pods */,
+				765F06D768402C52A064CE0C /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,7 +124,7 @@
 				E5D5794F18C0C5BF00CB26C6 /* CoreGraphics.framework */,
 				E5D5795118C0C5BF00CB26C6 /* UIKit.framework */,
 				E5D5796C18C0C5BF00CB26C6 /* XCTest.framework */,
-				97CA2ECF94904BA081442E00 /* libPods.a */,
+				2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -179,12 +179,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E5D5797C18C0C5BF00CB26C6 /* Build configuration list for PBXNativeTarget "ExampleProject" */;
 			buildPhases = (
-				FAD46DC6B4F04E249D43F760 /* Check Pods Manifest.lock */,
+				975AAD5D5EA24722235F6D2D /* [CP] Check Pods Manifest.lock */,
 				E5D5794618C0C5BF00CB26C6 /* Sources */,
 				E5D5794718C0C5BF00CB26C6 /* Frameworks */,
 				E5D5794818C0C5BF00CB26C6 /* Resources */,
-				583128B7DAEF417682F920CE /* Copy Pods Resources */,
-				E3CC90CEB5B1A11F82001AA3 /* Embed Pods Frameworks */,
+				60DCA6588B2162B046D15BAD /* [CP] Embed Pods Frameworks */,
+				758339AF641C30E4ADE11D38 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -269,44 +269,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		583128B7DAEF417682F920CE /* Copy Pods Resources */ = {
+		60DCA6588B2162B046D15BAD /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E3CC90CEB5B1A11F82001AA3 /* Embed Pods Frameworks */ = {
+		758339AF641C30E4ADE11D38 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FAD46DC6B4F04E249D43F760 /* Check Pods Manifest.lock */ = {
+		975AAD5D5EA24722235F6D2D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -446,7 +446,7 @@
 		};
 		E5D5797D18C0C5BF00CB26C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE01E62399C26D7FB91B549A /* Pods.debug.xcconfig */;
+			baseConfigurationReference = FA2FCC238AF00E32E3435D3F /* Pods-ExampleProject.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -462,7 +462,7 @@
 		};
 		E5D5797E18C0C5BF00CB26C6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7D4A04D5FB42A7EFEC05FB54 /* Pods.release.xcconfig */;
+			baseConfigurationReference = E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
+++ b/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
+++ b/Examples/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		31DD6CE306B535C55B5DF383 /* libPods-ExampleProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */; };
+		DFD26CA35CF6AB934F1F57F0 /* libPods-ExampleProject-ExampleProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A78F89CDC3BCC5318C5FEFEC /* libPods-ExampleProject-ExampleProject.a */; };
 		E5D5794E18C0C5BF00CB26C6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5794D18C0C5BF00CB26C6 /* Foundation.framework */; };
 		E5D5795018C0C5BF00CB26C6 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5794F18C0C5BF00CB26C6 /* CoreGraphics.framework */; };
 		E5D5795218C0C5BF00CB26C6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D5795118C0C5BF00CB26C6 /* UIKit.framework */; };
@@ -37,7 +38,10 @@
 /* Begin PBXFileReference section */
 		2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		62F8E15868BDAE2ADD4C33F5 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		715A600D9CA585253A85E669 /* Pods-ExampleProject-ExampleProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject-ExampleProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject-ExampleProject/Pods-ExampleProject-ExampleProject.release.xcconfig"; sourceTree = "<group>"; };
+		A78F89CDC3BCC5318C5FEFEC /* libPods-ExampleProject-ExampleProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleProject-ExampleProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject.release.xcconfig"; sourceTree = "<group>"; };
+		E2C9D899860F8394A610CC79 /* Pods-ExampleProject-ExampleProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleProject-ExampleProject.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExampleProject-ExampleProject/Pods-ExampleProject-ExampleProject.debug.xcconfig"; sourceTree = "<group>"; };
 		E5D5794A18C0C5BF00CB26C6 /* ExampleProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5D5794D18C0C5BF00CB26C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E5D5794F18C0C5BF00CB26C6 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -70,6 +74,7 @@
 				E5D5795218C0C5BF00CB26C6 /* UIKit.framework in Frameworks */,
 				E5D5794E18C0C5BF00CB26C6 /* Foundation.framework in Frameworks */,
 				31DD6CE306B535C55B5DF383 /* libPods-ExampleProject.a in Frameworks */,
+				DFD26CA35CF6AB934F1F57F0 /* libPods-ExampleProject-ExampleProject.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,6 +96,8 @@
 			children = (
 				FA2FCC238AF00E32E3435D3F /* Pods-ExampleProject.debug.xcconfig */,
 				E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */,
+				E2C9D899860F8394A610CC79 /* Pods-ExampleProject-ExampleProject.debug.xcconfig */,
+				715A600D9CA585253A85E669 /* Pods-ExampleProject-ExampleProject.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -125,6 +132,7 @@
 				E5D5795118C0C5BF00CB26C6 /* UIKit.framework */,
 				E5D5796C18C0C5BF00CB26C6 /* XCTest.framework */,
 				2A76C344EF451523FF7CF915 /* libPods-ExampleProject.a */,
+				A78F89CDC3BCC5318C5FEFEC /* libPods-ExampleProject-ExampleProject.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -281,7 +289,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject-ExampleProject/Pods-ExampleProject-ExampleProject-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		758339AF641C30E4ADE11D38 /* [CP] Copy Pods Resources */ = {
@@ -296,7 +304,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject/Pods-ExampleProject-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ExampleProject-ExampleProject/Pods-ExampleProject-ExampleProject-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		975AAD5D5EA24722235F6D2D /* [CP] Check Pods Manifest.lock */ = {
@@ -446,7 +454,7 @@
 		};
 		E5D5797D18C0C5BF00CB26C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FA2FCC238AF00E32E3435D3F /* Pods-ExampleProject.debug.xcconfig */;
+			baseConfigurationReference = E2C9D899860F8394A610CC79 /* Pods-ExampleProject-ExampleProject.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -462,7 +470,7 @@
 		};
 		E5D5797E18C0C5BF00CB26C6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0229972D711F3216940FD18 /* Pods-ExampleProject.release.xcconfig */;
+			baseConfigurationReference = 715A600D9CA585253A85E669 /* Pods-ExampleProject-ExampleProject.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/Examples/ExampleProject/ExampleProject.xcworkspace/contents.xcworkspacedata
+++ b/Examples/ExampleProject/ExampleProject.xcworkspace/contents.xcworkspacedata
@@ -1,1 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:ExampleProject.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ExampleProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:ExampleMacProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/ExampleProject/Podfile
+++ b/Examples/ExampleProject/Podfile
@@ -1,6 +1,20 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-target 'ExampleProject' do
-  platform :ios, '7.0'
+abstract_target 'ExampleProject' do
+  workspace 'ExampleProject.xcworkspace'
+
   pod 'LogglyLogger-CocoaLumberjack', :path => '../../'
+
+  target 'ExampleProject' do
+    platform :ios, '7.0'
+    inherit! :complete
+    project 'ExampleProject.xcodeproj'
+  end
+  target 'ExampleMacProject' do
+    platform :osx, '10.10'
+    inherit! :complete
+    use_frameworks!
+    project 'ExampleMacProject.xcodeproj'
+  end
 end
+

--- a/Examples/ExampleProject/Podfile
+++ b/Examples/ExampleProject/Podfile
@@ -1,4 +1,6 @@
-platform :ios, '7.0'
 source 'https://github.com/CocoaPods/Specs.git'
 
-pod 'LogglyLogger-CocoaLumberjack', :path => '../../'
+target 'ExampleProject' do
+  platform :ios, '7.0'
+  pod 'LogglyLogger-CocoaLumberjack', :path => '../../'
+end

--- a/Examples/ExampleProject/Podfile.lock
+++ b/Examples/ExampleProject/Podfile.lock
@@ -1,32 +1,30 @@
 PODS:
-  - CocoaLumberjack (2.3.0):
-    - CocoaLumberjack/Default (= 2.3.0)
-    - CocoaLumberjack/Extensions (= 2.3.0)
-  - CocoaLumberjack/Core (2.3.0)
-  - CocoaLumberjack/Default (2.3.0):
-    - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.3.0):
+  - CocoaLumberjack (3.1.0):
+    - CocoaLumberjack/Default (= 3.1.0)
+    - CocoaLumberjack/Extensions (= 3.1.0)
+  - CocoaLumberjack/Default (3.1.0)
+  - CocoaLumberjack/Extensions (3.1.0):
     - CocoaLumberjack/Default
-  - LogglyLogger-CocoaLumberjack (2.3.2):
-    - CocoaLumberjack (~> 2.0)
-    - LogglyLogger-CocoaLumberjack/Formatter (= 2.3.2)
-    - LogglyLogger-CocoaLumberjack/Logger (= 2.3.2)
-  - LogglyLogger-CocoaLumberjack/Formatter (2.3.2):
-    - CocoaLumberjack (~> 2.0)
-  - LogglyLogger-CocoaLumberjack/Logger (2.3.2):
-    - CocoaLumberjack (~> 2.0)
+  - LogglyLogger-CocoaLumberjack (3.0.0):
+    - CocoaLumberjack (~> 3.0)
+    - LogglyLogger-CocoaLumberjack/Formatter (= 3.0.0)
+    - LogglyLogger-CocoaLumberjack/Logger (= 3.0.0)
+  - LogglyLogger-CocoaLumberjack/Formatter (3.0.0):
+    - CocoaLumberjack (~> 3.0)
+  - LogglyLogger-CocoaLumberjack/Logger (3.0.0):
+    - CocoaLumberjack (~> 3.0)
 
 DEPENDENCIES:
-  - LogglyLogger-CocoaLumberjack (from `https://github.com/melke/LogglyLogger-CocoaLumberjack.git`)
+  - LogglyLogger-CocoaLumberjack (from `../../`)
 
 EXTERNAL SOURCES:
   LogglyLogger-CocoaLumberjack:
     :path: ../../
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 97fab7ee5f507fe54445cca7ea80f926729cfd15
-  LogglyLogger-CocoaLumberjack: 088aca1373786dca9da5fe8596eb0c9bfc4f39b7
+  CocoaLumberjack: 8311463ddf9ee86a06ef92a071dd656c89244500
+  LogglyLogger-CocoaLumberjack: 99ae9ec4d506b07655844b98781e566679e59018
 
 PODFILE CHECKSUM: 69c9d62f07f89107d5b43e1c7c73dfd7f69293cb
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.2.0

--- a/Examples/ExampleProject/Podfile.lock
+++ b/Examples/ExampleProject/Podfile.lock
@@ -7,13 +7,13 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - LogglyLogger-CocoaLumberjack (2.3.0):
+  - LogglyLogger-CocoaLumberjack (2.3.2):
     - CocoaLumberjack (~> 2.0)
-    - LogglyLogger-CocoaLumberjack/Formatter (= 2.3.0)
-    - LogglyLogger-CocoaLumberjack/Logger (= 2.3.0)
-  - LogglyLogger-CocoaLumberjack/Formatter (2.3.0):
+    - LogglyLogger-CocoaLumberjack/Formatter (= 2.3.2)
+    - LogglyLogger-CocoaLumberjack/Logger (= 2.3.2)
+  - LogglyLogger-CocoaLumberjack/Formatter (2.3.2):
     - CocoaLumberjack (~> 2.0)
-  - LogglyLogger-CocoaLumberjack/Logger (2.3.0):
+  - LogglyLogger-CocoaLumberjack/Logger (2.3.2):
     - CocoaLumberjack (~> 2.0)
 
 DEPENDENCIES:
@@ -21,10 +21,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   LogglyLogger-CocoaLumberjack:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  LogglyLogger-CocoaLumberjack: 1caf7e0dd0dbf9f571014310cd9476aa7c7fecf2
+  LogglyLogger-CocoaLumberjack: 088aca1373786dca9da5fe8596eb0c9bfc4f39b7
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 6816f03ab7508586a09cbb01e4731dd5ccf753db
+
+COCOAPODS: 1.0.1

--- a/Examples/ExampleProject/Podfile.lock
+++ b/Examples/ExampleProject/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - CocoaLumberjack (2.2.0):
-    - CocoaLumberjack/Default (= 2.2.0)
-    - CocoaLumberjack/Extensions (= 2.2.0)
-  - CocoaLumberjack/Core (2.2.0)
-  - CocoaLumberjack/Default (2.2.0):
+  - CocoaLumberjack (2.3.0):
+    - CocoaLumberjack/Default (= 2.3.0)
+    - CocoaLumberjack/Extensions (= 2.3.0)
+  - CocoaLumberjack/Core (2.3.0)
+  - CocoaLumberjack/Default (2.3.0):
     - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.2.0):
+  - CocoaLumberjack/Extensions (2.3.0):
     - CocoaLumberjack/Default
   - LogglyLogger-CocoaLumberjack (2.3.2):
     - CocoaLumberjack (~> 2.0)
@@ -24,9 +24,9 @@ EXTERNAL SOURCES:
     :path: ../../
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
+  CocoaLumberjack: 97fab7ee5f507fe54445cca7ea80f926729cfd15
   LogglyLogger-CocoaLumberjack: 088aca1373786dca9da5fe8596eb0c9bfc4f39b7
 
-PODFILE CHECKSUM: 6816f03ab7508586a09cbb01e4731dd5ccf753db
+PODFILE CHECKSUM: 69c9d62f07f89107d5b43e1c7c73dfd7f69293cb
 
 COCOAPODS: 1.0.1

--- a/LogglyLogger-CocoaLumberjack.podspec
+++ b/LogglyLogger-CocoaLumberjack.podspec
@@ -21,7 +21,10 @@ Pod::Spec.new do |s|
 
   s.author       = { "Mats Melke" => "mats@melke.nu" }
 
-  s.ios.deployment_target = '7.0'
+  s.platforms    = {
+    :ios => "7.0",
+    :osx => "10.10"
+  }
 
   s.source       = { :git => "https://github.com/melke/LogglyLogger-CocoaLumberjack.git", :tag => "2.3.2" }
 

--- a/LogglyLogger-CocoaLumberjack/LogglyFields.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyFields.m
@@ -4,7 +4,15 @@
 
 #import "LogglyFields.h"
 
-@import UIKit;
+#define TARGET_MAC_DESKTOP !(TARGET_IPHONE || TARGET_OS_SIMULATOR)
+
+#if TARGET_MAC_DESKTOP
+#import <Foundation/Foundation.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+
+@import Foundation;
 
 @implementation LogglyFields {
     dispatch_queue_t _queue;
@@ -29,9 +37,11 @@
         if(bundleVersion != nil) {
             [dict setObject:bundleVersion forKey:@"appversion"];
         }
-        [dict setObject:[UIDevice currentDevice].name forKey:@"devicename"];
-        [dict setObject:[UIDevice currentDevice].model forKey:@"devicemodel"];
-        [dict setObject:[UIDevice currentDevice].systemVersion forKey:@"osversion"];
+        
+        // TODO: use x-platform UIDevice abstraction
+//        [dict setObject:[UIDevice currentDevice].name forKey:@"devicename"];
+//        [dict setObject:[UIDevice currentDevice].model forKey:@"devicemodel"];
+//        [dict setObject:[UIDevice currentDevice].systemVersion forKey:@"osversion"];
         [dict setObject:[self generateRandomStringWithSize:10] forKey:@"sessionid"];
         _fieldsDictionary = [NSDictionary dictionaryWithDictionary:dict];
     }

--- a/LogglyLogger-CocoaLumberjack/LogglyFields.m
+++ b/LogglyLogger-CocoaLumberjack/LogglyFields.m
@@ -7,9 +7,24 @@
 #define TARGET_MAC_DESKTOP !(TARGET_IPHONE || TARGET_OS_SIMULATOR)
 
 #if TARGET_MAC_DESKTOP
+
 #import <Foundation/Foundation.h>
+#include <sys/sysctl.h>
+
+static NSString* sysctlDeviceModel() {
+    size_t size;
+    sysctlbyname("hw.model", NULL, &size, NULL, 0);
+    char *model = malloc(size);
+    sysctlbyname("hw.model", model, &size, NULL, 0);
+    NSString *sDeviceModel = @(model);
+    free(model);
+    return sDeviceModel;
+}
+
 #else
+
 #import <UIKit/UIKit.h>
+
 #endif
 
 @import Foundation;
@@ -38,10 +53,16 @@
             [dict setObject:bundleVersion forKey:@"appversion"];
         }
         
-        // TODO: use x-platform UIDevice abstraction
-//        [dict setObject:[UIDevice currentDevice].name forKey:@"devicename"];
-//        [dict setObject:[UIDevice currentDevice].model forKey:@"devicemodel"];
-//        [dict setObject:[UIDevice currentDevice].systemVersion forKey:@"osversion"];
+#if TARGET_MAC_DESKTOP
+        dict[@"devicename"] = [[NSHost currentHost] name];
+        dict[@"devicemodel"] = sysctlDeviceModel();
+        NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
+        dict[@"osversion"] = [NSString stringWithFormat:@"%d.%d.%d", osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion];
+#else
+        [dict setObject:[UIDevice currentDevice].name forKey:@"devicename"];
+        [dict setObject:[UIDevice currentDevice].model forKey:@"devicemodel"];
+        [dict setObject:[UIDevice currentDevice].systemVersion forKey:@"osversion"];
+#endif
         [dict setObject:[self generateRandomStringWithSize:10] forKey:@"sessionid"];
         _fieldsDictionary = [NSDictionary dictionaryWithDictionary:dict];
     }


### PR DESCRIPTION
Adds MacOS example project & platform support in the podspec. Ensures Mac device info is captured automatically, as is currently done for iOS.