### PR TITLE
Import public headers in LogglyLogger.h

### DIFF
--- a/LogglyLogger-CocoaLumberjack/LogglyLogger.h
+++ b/LogglyLogger-CocoaLumberjack/LogglyLogger.h
@@ -6,6 +6,8 @@
 #import <CocoaLumberjack/CocoaLumberjack.h>
 #import <CocoaLumberjack/DDAbstractDatabaseLogger.h>
 
+#import "LogglyFormatter.h"
+#import "LogglyFields.h"
 
 @interface LogglyLogger : DDAbstractDatabaseLogger
 


### PR DESCRIPTION
Allows LogglyLogger.h to be used as the umbrella header, which makes
importing from a submodule easier.